### PR TITLE
feat: add Tailwind CSS to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,7 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+
+gem "tailwindcss-ruby", "~> 4.0"
+
+gem "tailwindcss-rails", "~> 4.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,6 +335,15 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.5)
+    tailwindcss-rails (4.2.0)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.0.12)
+    tailwindcss-ruby (4.0.12-aarch64-linux-gnu)
+    tailwindcss-ruby (4.0.12-aarch64-linux-musl)
+    tailwindcss-ruby (4.0.12-arm64-darwin)
+    tailwindcss-ruby (4.0.12-x86_64-linux-gnu)
+    tailwindcss-ruby (4.0.12-x86_64-linux-musl)
     thor (1.3.2)
     thruster (0.1.11)
     thruster (0.1.11-aarch64-linux)
@@ -396,6 +405,8 @@ DEPENDENCIES
   solid_queue
   sqlite3 (>= 2.1)
   stimulus-rails
+  tailwindcss-rails (~> 4.2)
+  tailwindcss-ruby (~> 4.0)
   thruster
   turbo-rails
   tzinfo-data

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
-<div class="is-flex is-justify-content-center">
+<div class="flex justify-center pt-5">
   <svg width="500" height="200" viewBox="0 0 500 200" xmlns="http://www.w3.org/2000/svg">
     <!-- Texto estilizado -->
     <text x="50%" y="50%" font-size="60" font-family="sans-serif" fill="black" text-anchor="middle" dominant-baseline="middle">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -17,4 +17,5 @@
     <path d="M380 100 L400 40 L420 100" stroke="black" stroke-width="6" /> <!-- A -->
     <path d="M440 40 L460 100 L480 40" stroke="black" stroke-width="6" /> <!-- M -->
   </svg>
+
 </div>

--- a/bin/dev
+++ b/bin/dev
@@ -1,2 +1,16 @@
-#!/usr/bin/env ruby
-exec "./bin/rails", "server", *ARGV
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Add Tailwind CSS to the project
Description
This PR adds Tailwind CSS to the project. The necessary dependencies have been installed, enabling the use of Tailwind utility classes.

Changes
Installed Tailwind CSS and its dependencies
Integrated Tailwind into the project without additional configuration